### PR TITLE
cast size_t to int32_t for vector::size

### DIFF
--- a/libdebug/cpp/source/PS4DBG.cpp
+++ b/libdebug/cpp/source/PS4DBG.cpp
@@ -282,7 +282,7 @@ namespace libdebug
 	{
 		CheckConnected();
 
-		SendCMDPacket(CMDS::CMD_PROC_WRITE, CMD_PROC_WRITE_PACKET_SIZE, { pid, address, data.size()});
+		SendCMDPacket(CMDS::CMD_PROC_WRITE, CMD_PROC_WRITE_PACKET_SIZE, { pid, address, (int32_t) data.size()});
 		CheckStatus();
 		SendData(data, data.size());
 		CheckStatus();
@@ -372,7 +372,7 @@ namespace libdebug
 	void PS4DBG::LoadElf(int32_t pid, const std::vector<uint8_t> &elf)
 	{
 
-		SendCMDPacket(CMDS::CMD_PROC_ELF, CMD_PROC_ELF_PACKET_SIZE, { pid, elf.size() });
+		SendCMDPacket(CMDS::CMD_PROC_ELF, CMD_PROC_ELF_PACKET_SIZE, { pid, (int32_t) elf.size() });
 		SendData(elf, elf.size());
 		CheckStatus();
 	}
@@ -461,7 +461,7 @@ namespace libdebug
 	{
 		CheckConnected();
 
-		SendCMDPacket(CMDS::CMD_KERN_WRITE, CMD_KERN_WRITE_PACKET_SIZE, { address, data.size() });
+		SendCMDPacket(CMDS::CMD_KERN_WRITE, CMD_KERN_WRITE_PACKET_SIZE, { address, (int32_t) data.size() });
 		CheckStatus();
 		SendData(data, data.size());
 		CheckStatus();


### PR DESCRIPTION
Hello,

In the C++ libdebug code, the write methods are using `size_t vector::size()`, but the size of size_t isn't 4 bytes by default. In my version `sizeof(size_t) = 8`, so it was creating a buffer overflow.

This PR fixes it for the LoadElf/KernelWriteMemory/WriteMemory methods, but maybe it's used somewhere else.

Thanks for the lib itself.